### PR TITLE
Document the usage of `Mail.Headers` and `Mailable.Headers`

### DIFF
--- a/digging-deeper/mail.md
+++ b/digging-deeper/mail.md
@@ -21,6 +21,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-foo": "Bar"}).
   Send()
 ```
 
@@ -35,6 +36,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Queue()
 ```
 
@@ -49,6 +51,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Queue(mail.Queue().Connection("redis").Queue("mail"))
 ```
 
@@ -66,6 +69,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "bar"}).
   Queue(mail.Queue().Connection("redis").Queue("mail"))
 ```
 
@@ -87,6 +91,12 @@ type OrderShipped struct {
 
 func NewOrderShipped() *OrderShipped {
 	return &OrderShipped{}
+}
+
+func (m *OrderShipped) Headers() map[string]string {
+	return map[string]string{
+		"X-Foo": "Bar",
+	}
 }
 
 func (m *OrderShipped) Attachments() []string {

--- a/zh/digging-deeper/mail.md
+++ b/zh/digging-deeper/mail.md
@@ -21,6 +21,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Send()
 ```
 
@@ -35,6 +36,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Queue()
 ```
 
@@ -49,6 +51,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Queue(mail.Queue().Connection("redis").Queue("mail"))
 ```
 
@@ -66,6 +69,7 @@ err := facades.Mail().To([]string{"example@example.com"}).
   Attach([]string{"file.png"}).
   Content(mail.Html("<h1>Hello Goravel</h1>")).
   Subject("Subject").
+  Headers(map[string]string{"X-Foo": "Bar"}).
   Queue(mail.Queue().Connection("redis").Queue("mail"))
 ```
 
@@ -87,6 +91,12 @@ type OrderShipped struct {
 
 func NewOrderShipped() *OrderShipped {
 	return &OrderShipped{}
+}
+
+func (receiver *OrderShipped) Headers() map[string]string {
+	return map[string]string{
+		"X-Foo": "Bar",
+	}
 }
 
 func (m *OrderShipped) Attachments() []string {


### PR DESCRIPTION
This adds the `Headers()` method to both the `Mail` and `Mailable` examples.

This complements PR https://github.com/goravel/framework/pull/964